### PR TITLE
chore: update versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.14.3"
+          terraform_version: "1.15.8"
 
       - name: Check is doc is update to date
         run: |
@@ -36,7 +36,7 @@ jobs:
               exit 1
           fi
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@v6
         name: Setup TFLint
 
       - name: Init TFLint

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.15.8"
 
@@ -30,7 +30,7 @@ jobs:
               exit 1
           fi
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@v6
         name: Setup TFLint
 
       - name: Init TFLint

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.14.3"
+          terraform_version: "1.15.8"
 
       - name: Check is doc is update to date
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.terraform/
+**/dockerconfig.json
 *.secrets.auto.tfvars
 secrets.auto.tfvars
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: ## Display this help.
 ##@ Dev
 .PHONY: doc
 doc: ## Generate the doc
-	docker run --rm --volume "$$(pwd):/terraform-docs" -u $$(id -u) quay.io/terraform-docs/terraform-docs:0.19.0 markdown /terraform-docs > README.md
+	docker run --rm --volume "$$(pwd):/terraform-docs" -u $$(id -u) quay.io/terraform-docs/terraform-docs markdown /terraform-docs > README.md
 
 
 .PHONY: lint 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ You can find examples of code that uses this Terraform module in the [examples](
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~>6.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~>3.6 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | ~>4.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~>7.46 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~>3.9 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~>4.3 |
 
 
 ## Outputs

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -10,11 +10,11 @@ variable "project" {
 
 # ----------- Terraform setup ----------- #
 terraform {
-  required_version = ">1.8"
+  required_version = ">1.10"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>6.3"
+      version = "~>7.46"
     }
   }
 }
@@ -27,7 +27,7 @@ provider "google" {
 # ------ Main ------ #
 module "nebuly" {
   source  = "nebuly-ai/nebuly-platform/gcp"
-  version = ">=0.1.0"
+  version = ">=0.7.0"
 
   region          = var.region
   resource_prefix = "nbldev"

--- a/examples/microsoft-sso/main.tf
+++ b/examples/microsoft-sso/main.tf
@@ -10,11 +10,11 @@ variable "project" {
 
 # ----------- Terraform setup ----------- #
 terraform {
-  required_version = ">1.8"
+  required_version = ">1.10"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>6.3"
+      version = "~>7.46"
     }
   }
 }
@@ -27,7 +27,7 @@ provider "google" {
 # ------ Main ------ #
 module "nebuly" {
   source  = "nebuly-ai/nebuly-platform/gcp"
-  version = ">=0.1.0"
+  version = ">=0.7.0"
 
   region          = var.region
   resource_prefix = "nbldev"

--- a/examples/okta-sso/main.tf
+++ b/examples/okta-sso/main.tf
@@ -10,11 +10,11 @@ variable "project" {
 
 # ----------- Terraform setup ----------- #
 terraform {
-  required_version = ">1.8"
+  required_version = ">1.10"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>6.3"
+      version = "~>7.46"
     }
   }
 }
@@ -27,7 +27,7 @@ provider "google" {
 # ------ Main ------ #
 module "nebuly" {
   source  = "nebuly-ai/nebuly-platform/gcp"
-  version = ">=0.1.0"
+  version = ">=0.7.0"
 
   region          = var.region
   resource_prefix = "nbldev"

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>6.3.0"
+      version = "~>7.46"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.6"
+      version = "~>3.9"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~>4.0"
+      version = "~>4.3"
     }
   }
 }

--- a/tests/dev-provisioning/main.tf
+++ b/tests/dev-provisioning/main.tf
@@ -48,6 +48,11 @@ module "platform" {
   region          = var.region
   resource_prefix = "dev-"
 
+  postgres_server_delete_protection = false
+  postgres_server_high_availability = {
+    enabled = false
+  }
+
   gke_cluster_admin_users = [
     "d.cantella@nebuly.ai",
   ]

--- a/tests/dev-provisioning/main.tf
+++ b/tests/dev-provisioning/main.tf
@@ -1,11 +1,11 @@
 # ----------- Terraform setup ----------- #
 terraform {
-  required_version = ">1.8"
+  required_version = ">1.10"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~>6.3"
+      version = "~>7.46"
     }
   }
 }
@@ -36,6 +36,10 @@ variable "nebuly_credentials" {
   })
 }
 
+variable "openai_api_key" {
+  type = string
+}
+
 
 # ------ Main ------ #
 module "platform" {
@@ -44,13 +48,8 @@ module "platform" {
   region          = var.region
   resource_prefix = "dev-"
 
-  postgres_server_delete_protection = false
-  postgres_server_high_availability = {
-    enabled = false
-  }
-
   gke_cluster_admin_users = [
-    "m.zanotti@nebuly.ai",
+    "d.cantella@nebuly.ai",
   ]
   gke_delete_protection = false
   # gke_private_cluster_config = {
@@ -59,15 +58,72 @@ module "platform" {
   #   master_ipv4_cidr_block  = "172.172.16.0/28"
   # }
 
-  openai_api_key                     = "my-key"
-  openai_endpoint                    = "https://api.openai.com"
+  openai_api_key                     = var.openai_api_key
+  openai_endpoint                    = "https://api.openai.com/v1"
   openai_gpt4o_deployment_name       = "gpt-4o"
+  openai_gpt5_deployment_name        = "gpt-5"
   openai_translation_deployment_name = "gpt-4o-mini"
 
   microsoft_sso = var.microsoft_sso
 
   platform_domain    = "platform.gcp.testing.nebuly.com"
   nebuly_credentials = var.nebuly_credentials
+
+  gke_kubernetes_version = "1.36."
+  gke_node_pools = {
+    "web-services" : {
+      machine_type = "n2-highmem-4"
+      min_nodes    = 1
+      max_nodes    = 1
+      node_count   = 1
+      resource_labels = {
+        "goog-gke-node-pool-provisioning-model" = "on-demand"
+      }
+    }
+    "clickhouse" : {
+      machine_type = "n2-highmem-4"
+      min_nodes    = 1
+      max_nodes    = 1
+      node_count   = 1
+      disk_type    = "pd-ssd"
+      disk_size_gb = 128
+      resource_labels = {
+        "goog-gke-node-pool-provisioning-model" = "on-demand"
+      }
+      labels = {
+        "nebuly.com/reserved" : "clickhouse"
+      }
+      taints = [
+        {
+          key    = "nebuly.com/reserved"
+          value  = "clickhouse"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    }
+    "gpu-primary" : {
+      machine_type = "a2-highgpu-1g"
+      min_nodes    = 0
+      max_nodes    = 1
+      node_count   = null
+      node_locations = [
+        "europe-west4-a",
+        "europe-west4-b",
+      ]
+      guest_accelerator = {
+        type  = "nvidia-tesla-a100"
+        count = 1
+      }
+      labels = {
+        "gke-no-default-nvidia-gpu-device-plugin" : true,
+        "nebuly.com/accelerator" : "nvidia-tesla-a100",
+      }
+      resource_labels = {
+        "goog-gke-accelerator-type"             = "nvidia-tesla-a100"
+        "goog-gke-node-pool-provisioning-model" = "on-demand"
+      }
+    }
+  }
 }
 
 output "gke_cluster_get_credentials" {
@@ -75,7 +131,9 @@ output "gke_cluster_get_credentials" {
 }
 output "helm_values" {
   value = module.platform.helm_values
+  sensitive = true
 }
 output "secret_provider_class" {
   value = module.platform.secret_provider_class
+  sensitive = true
 }

--- a/tests/dev-provisioning/terraform.auto.tfvars
+++ b/tests/dev-provisioning/terraform.auto.tfvars
@@ -1,1 +1,1 @@
-region = "us-central1"
+region = "europe-west4"

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 }
 
 variable "credentials" {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/terraform-google-nebuly-platform/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790352667&installation_model_id=423910&pr_number=3&repository=nebuly-ai%2Fterraform-google-nebuly-platform&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fterraform-google-nebuly-platform%2Fpull%2F3&signature=6ef5d3b0842a9495fcf5151b4ab07df5ade81d374062247362e5967d160ccd26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The jump to Terraform 1.10+ and google provider ~7.x can surface breaking plan/apply behavior for all module consumers; dev-provisioning GKE/GPU pool changes affect only the internal test environment.
> 
> **Overview**
> Bumps the **Terraform** floor to **>= 1.10** and refreshes **provider pins** across the root module, examples, and tests—**google** `~>7.46`, **random** `~>3.9`, **tls** `~>4.3**—with **README** provider tables regenerated. Example stacks now require module **`>=0.7.0`**.
> 
> **CI** (`ci.yaml`, `pull-requests.yaml`) moves to **checkout@v7**, **setup-terraform@v4** with **Terraform 1.15.8**, and **setup-tflint@v6**. **`make doc`** uses the floating **`terraform-docs`** image tag instead of **0.19.0**. **`.gitignore`** adds **`**/dockerconfig.json`**.
> 
> The **dev-provisioning** test stack is retargeted to **`europe-west4`**, takes **`openai_api_key`** as a variable (OpenAI base URL **`/v1`**, **GPT-5** deployment), pins **GKE 1.36** with explicit **web / ClickHouse / GPU** node pools, marks **helm** and **secret provider** outputs **sensitive**, and updates the cluster admin contact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf43a992f5fcf2ea035fa6da2b74a598ebaaf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->